### PR TITLE
Suppress app icon for GWorkspace

### DIFF
--- a/install-agora-git.sh
+++ b/install-agora-git.sh
@@ -114,6 +114,7 @@ defaults write NSGlobalDomain NSInterfaceStyleDefault NSMacintoshInterfaceStyle
 defaults write NSGlobalDomain NSMenuInterfaceStyle NSMacintoshInterfaceStyle
 
 defaults write NSGlobalDomain GSFileBrowserHideDotFiles YES
+defaults write GWorkspace GSSuppressAppIcon YES
 
 cat > /tmp/agora.root.hidden <<EOF
 bin


### PR DESCRIPTION
- More scripting done
- Added GWorkspace to installer script
- Added defaults settings to the installer.
- Cleanup
- Fixed critical error in defaults settings for GSBackend
- GWorkspace no longer displays dotfiles or the Unix directories by default.
- Create more directories before installing
- Added libx-corebase to the installtion script.
- Added Terminal.app to build script.
- Suppress app icon for GWorkspace
