### PR TITLE
Update the installer script to run on a fresh install

### DIFF
--- a/install-agora-git.sh
+++ b/install-agora-git.sh
@@ -29,8 +29,11 @@ sudo pkg install bash gmake cmake libffcall libxml2 libxslt openssl \
 # install gnustep-make
 [ -d "tools-make" ] || git clone https://github.com/AgoraDesktop/tools-make.git
 cd tools-make
-./configure --with-layout=agora
 git pull --rebase --autostash
+./configure \
+	--with-layout=agora \
+	--with-library-combo=ng-gnu-gnu \
+	--enable-objc-arc
 gmake
 sudo gmake install && sudo gmake clean
 cd $AGORA_HOME

--- a/install-agora-git.sh
+++ b/install-agora-git.sh
@@ -24,7 +24,7 @@ cd $AGORA_HOME
 # install prerequisites
 sudo pkg install bash gmake cmake libffcall libxml2 libxslt openssl \
     libiconv giflib aspell cups libaudiofile portaudio libart_lgpl \
-    windowmaker cairo libsvg-cairo harfbuzz-cairo libdispatch icu
+    windowmaker cairo libsvg-cairo harfbuzz-cairo libdispatch icu xorg
 
 # install gnustep-make
 [ -d "tools-make" ] || git clone https://github.com/AgoraDesktop/tools-make.git

--- a/install-agora-git.sh
+++ b/install-agora-git.sh
@@ -100,7 +100,7 @@ cd $AGORA_HOME
 [ -d "libs-corebase" ] || git clone https://github.com/AgoraDesktop/libs-corebase.git
 cd libs-corebase
 git pull --rebase --autostash
-CFLAGS=-I/Library/Headers LDFLAGS=-L/Library/Libraries ./configure
+CFLAGS=$(gnustep-config --objc-flags) LDFLAGS=$(gnustep-config --objc-libs) ./configure
 gmake -j8
 sudo gmake install
 gmake clean

--- a/install-agora-git.sh
+++ b/install-agora-git.sh
@@ -27,9 +27,10 @@ sudo pkg install bash gmake cmake libffcall libxml2 libxslt openssl \
     windowmaker cairo libsvg-cairo harfbuzz-cairo libdispatch
 
 # install gnustep-make
-git clone https://github.com/AgoraDesktop/tools-make.git
+[ -d "tools-make" ] || git clone https://github.com/AgoraDesktop/tools-make.git
 cd tools-make
 ./configure --with-layout=agora
+git pull --rebase --autostash
 gmake
 sudo gmake install && sudo gmake clean
 cd $AGORA_HOME
@@ -37,8 +38,9 @@ cd $AGORA_HOME
 . /System/Library/Makefiles/GNUstep.sh
 
 # install libobjc2
-git clone https://github.com/AgoraDesktop/libobjc2.git
+[ -d "libobjc2" ] || git clone https://github.com/AgoraDesktop/libobjc2.git
 cd libobjc2
+git pull --rebase --autostash
 git submodule update --init
 mkdir Build
 cd Build 
@@ -49,9 +51,12 @@ cd ..
 rm -rf Build
 cd $AGORA_HOME
 
+sudo -E ldconfig
+
 # install gnustep-base
-git clone https://github.com/AgoraDesktop/libs-base.git
+[ -d "libs-base" ] || git clone https://github.com/AgoraDesktop/libs-base.git
 cd libs-base
+git pull --rebase --autostash
 ./configure
 gmake -j8
 sudo gmake install
@@ -59,8 +64,9 @@ gmake clean
 cd $AGORA_HOME
 
 # install gnustep-gui
-git clone https://github.com/AgoraDesktop/libs-gui.git
+[ -d "libs-gui" ] || git clone https://github.com/AgoraDesktop/libs-gui.git
 cd libs-gui
+git pull --rebase --autostash
 ./configure
 gmake -j8
 sudo gmake install
@@ -68,8 +74,9 @@ gmake clean
 cd $AGORA_HOME
 
 # install gnustep-back
-git clone https://github.com/AgoraDesktop/libs-back.git
+[ -d "libs-back" ] || git clone https://github.com/AgoraDesktop/libs-back.git
 cd libs-back
+git pull --rebase --autostash
 ./configure --enable-server=x11 --enable-graphics=cairo
 gmake -j8
 sudo gmake install
@@ -77,8 +84,9 @@ gmake clean
 cd $AGORA_HOME
 
 # install GWorkspace
-git clone https://github.com/AgoraDesktop/apps-gworkspace.git
+[ -d "apps-gworkspace" ] || git clone https://github.com/AgoraDesktop/apps-gworkspace.git
 cd apps-gworkspace
+git pull --rebase --autostash
 ./configure
 gmake -j8
 sudo gmake install
@@ -86,8 +94,9 @@ gmake clean
 cd $AGORA_HOME
 
 # install libs-corebase
-git clone https://github.com/AgoraDesktop/libs-corebase.git
+[ -d "libs-corebase" ] || git clone https://github.com/AgoraDesktop/libs-corebase.git
 cd libs-corebase
+git pull --rebase --autostash
 CFLAGS=-I/Library/Headers LDFLAGS=-L/Library/Libraries ./configure
 gmake -j8
 sudo gmake install
@@ -95,8 +104,9 @@ gmake clean
 cd $AGORA_HOME
 
 #install Terminal.app
-git clone https://github.com/AgoraDesktop/apps-terminal.git
+[ -d "apps-terminal" ] || git clone https://github.com/AgoraDesktop/apps-terminal.git
 cd apps-terminal
+git pull --rebase --autostash
 gmake -j8
 sudo gmake install
 gmake clean

--- a/install-agora-git.sh
+++ b/install-agora-git.sh
@@ -22,7 +22,7 @@ sudo mkdir -p /Library/Icons
 cd $AGORA_HOME
 
 # install prerequisites
-pkg install bash gmake cmake libffcall libxml2 libxslt openssl \
+sudo pkg install bash gmake cmake libffcall libxml2 libxslt openssl \
     libiconv giflib aspell cups libaudiofile portaudio libart_lgpl \
     windowmaker cairo libsvg-cairo harfbuzz-cairo libdispatch
 

--- a/install-agora-git.sh
+++ b/install-agora-git.sh
@@ -1,15 +1,25 @@
-#!/usr/local/bin/bash
+#!/bin/sh
 
-pushd $HOME
+# Terminate script on error
+set -e
 
-mkdir -p $HOME/Development/Agora
+CWD=$(pwd)
+DEV_HOME=${DEV_HOME:-$HOME/Development}
+AGORA_HOME=$DEV_HOME/Agora
+
+# Verify that sudo is installed
+[ -x "$(which sudo)" ] || (echo "This script requires sudo to be installed." && exit 1)
+
+cd $HOME
+
+mkdir -p $AGORA_HOME
 mkdir -p $HOME/Documents
 mkdir -p $HOME/Library/Wallpaper
 mkdir -p $HOME/Library/Icons
 sudo mkdir -p /Library/Wallpaper
 sudo mkdir -p /Library/Icons
 
-pushd $HOME/Development/Agora
+cd $AGORA_HOME
 
 # install prerequisites
 pkg install bash gmake cmake libffcall libxml2 libxslt openssl \
@@ -18,17 +28,17 @@ pkg install bash gmake cmake libffcall libxml2 libxslt openssl \
 
 # install gnustep-make
 git clone https://github.com/AgoraDesktop/tools-make.git
-pushd tools-make
+cd tools-make
 ./configure --with-layout=agora
 gmake
 sudo gmake install && sudo gmake clean
-popd
+cd $AGORA_HOME
 # Load the shell environment for gnustep-make
 . /System/Library/Makefiles/GNUstep.sh
 
 # install libobjc2
 git clone https://github.com/AgoraDesktop/libobjc2.git
-pushd libobjc2
+cd libobjc2
 git submodule update --init
 mkdir Build
 cd Build 
@@ -37,63 +47,61 @@ gmake
 sudo gmake install
 cd ..
 rm -rf Build
-popd
+cd $AGORA_HOME
 
 # install gnustep-base
 git clone https://github.com/AgoraDesktop/libs-base.git
-pushd libs-base
+cd libs-base
 ./configure
 gmake -j8
 sudo gmake install
 gmake clean
-popd
+cd $AGORA_HOME
 
 # install gnustep-gui
 git clone https://github.com/AgoraDesktop/libs-gui.git
-pushd libs-gui
+cd libs-gui
 ./configure
 gmake -j8
 sudo gmake install
 gmake clean
-popd
+cd $AGORA_HOME
 
 # install gnustep-back
 git clone https://github.com/AgoraDesktop/libs-back.git
-pushd libs-back
+cd libs-back
 ./configure --enable-server=x11 --enable-graphics=cairo
 gmake -j8
 sudo gmake install
 gmake clean
-popd
+cd $AGORA_HOME
 
 # install GWorkspace
 git clone https://github.com/AgoraDesktop/apps-gworkspace.git
-pushd apps-gworkspace
+cd apps-gworkspace
 ./configure
 gmake -j8
 sudo gmake install
 gmake clean
-popd
+cd $AGORA_HOME
 
 # install libs-corebase
 git clone https://github.com/AgoraDesktop/libs-corebase.git
-pushd libs-corebase
+cd libs-corebase
 CFLAGS=-I/Library/Headers LDFLAGS=-L/Library/Libraries ./configure
 gmake -j8
 sudo gmake install
 gmake clean
-popd
+cd $AGORA_HOME
 
 #install Terminal.app
 git clone https://github.com/AgoraDesktop/apps-terminal.git
-pushd apps-terminal
+cd apps-terminal
 gmake -j8
 sudo gmake install
 gmake clean
-popd
 
-popd
-
+cd $PWD
 
 # Set up user defaults
 defaults write NSGlobalDomain GSFirstControlKey Control_L 

--- a/install-agora-git.sh
+++ b/install-agora-git.sh
@@ -24,7 +24,7 @@ cd $AGORA_HOME
 # install prerequisites
 sudo pkg install bash gmake cmake libffcall libxml2 libxslt openssl \
     libiconv giflib aspell cups libaudiofile portaudio libart_lgpl \
-    windowmaker cairo libsvg-cairo harfbuzz-cairo libdispatch
+    windowmaker cairo libsvg-cairo harfbuzz-cairo libdispatch icu
 
 # install gnustep-make
 [ -d "tools-make" ] || git clone https://github.com/AgoraDesktop/tools-make.git


### PR DESCRIPTION
This PR contains several adjustments I made to the script as I attempted to run it from a fresh FreeBSD install.

- Run with `/bin/sh` and not `/usr/local/bin/bash` since it isn't installed yet
- terminate the script if an error happens
- use `sudo` to install the dependent packages
- add `icu` as a dependency
- add `xorg` as a dependency
- adjust configure options to `tools-make` to make it properly point to `libobjc`
- generate the `CFLAGS` and `LDFLAGS` with `gnu step-config` when building `libs-corebase` (it wasn't able to find the objc runtime headers)
