### PR TITLE
Added zsh to prerequisites, and installed default zsh profile information to load GNUStep environment.

### DIFF
--- a/install-agora-git.sh
+++ b/install-agora-git.sh
@@ -24,7 +24,7 @@ cd $AGORA_HOME
 # install prerequisites
 sudo pkg install bash gmake cmake libffcall libxml2 libxslt openssl git \
     libiconv giflib aspell cups libaudiofile portaudio libart_lgpl \
-    windowmaker cairo libsvg-cairo harfbuzz-cairo libdispatch icu xorg
+    windowmaker cairo libsvg-cairo harfbuzz-cairo libdispatch icu xorg zsh
 
 # install gnustep-make (First pass)
 [ -d "tools-make" ] || git clone https://github.com/AgoraDesktop/tools-make.git
@@ -182,8 +182,20 @@ nohup.out
 GNUstep
 EOF
 
+#configure for zsh
+sudo cat > /tmp/agora.zprofile <<EOF
+for file in /usr/local/etc/zprofile.d/*.zsh; do
+	source "\$file"
+done
+EOF
+[ -d /usr/local/etc ] || (sudo mkdir /usr/local/etc)
+[ -d /usr/local/etc/zprofile.d ] || (sudo mkdir /usr/local/etc/zprofile.d)
+[ -f /usr/local/etc/zprofile ] || (sudo mv /tmp/agora.zprofile /usr/local/etc/zprofile)
+sudo ln -sf `gnustep-config --variable=GNUSTEP_MAKEFILES`/GNUstep.sh /usr/local/etc/zprofile.d/GNUstep.zsh
 
-[ -d /usr/local/etc ] || (sudo mkdir -p /usr/local/etc/profile.d)
+#configure for sh and bash
+[ -d /usr/local/etc ] || (sudo mkdir /usr/local/etc)
+[ -d /usr/local/etc/profile.d ] || (sudo mkdir /usr/local/etc/profile.d)
 [ -f /usr/local/etc/profile ] || (sudo ln -sf /etc/profile /usr/local/etc/profile)
 [ -f /usr/local/etc/profile.d/GNUstep.sh ] || (sudo ln -sf `gnustep-config --variable=GNUSTEP_MAKEFILES`/GNUstep.sh /usr/local/etc/profile.d/GNUstep.sh)
 


### PR DESCRIPTION
This patch adds zsh to the Agora installation, and preconfigures it to 
load the GNUstep env vars properly. The installer script itself has also 
been tested to work under zsh. This does not change the user's current 
shell; that is up to them. If there is ever a respun FreeBSD+Agora installer,
it should probably set zsh as the default user shell.
